### PR TITLE
Add List-Unsubscribe headers to email

### DIFF
--- a/docs/working-with-lists/unsubscribing-from-a-list.md
+++ b/docs/working-with-lists/unsubscribing-from-a-list.md
@@ -32,6 +32,10 @@ Alternatively, you can call unsubscribe on a subscriber
 Subscriber::findForEmail('john@example.com')->unsubscribe();
 ```
 
+## Unsubscribing using an email client
+
+Emails sent have the ```List-Unsubscribe``` header included. This allows for users to unsubscribe from their email client as per [RFC2369](https://www.ietf.org/rfc/rfc2369.txt).
+
 ## Permanently deleting a subscriber
 
 Behind the scenes, the subscriber and the subscription will not be deleted. Instead, the status of the subscription will be updated to `unsubscribed`.

--- a/src/EmailCampaignsServiceProvider.php
+++ b/src/EmailCampaignsServiceProvider.php
@@ -59,7 +59,7 @@ class EmailCampaignsServiceProvider extends ServiceProvider
     {
         Route::macro('emailCampaigns', function () {
             Route::get('/confirm-subscription/{subscriptionUuid}', ConfirmSubscriptionController::class);
-            Route::get('/unsubscribe/{subscriptionUuid}', UnsubscribeController::class);
+            Route::match(['get', 'post'], '/unsubscribe/{subscriptionUuid}', UnsubscribeController::class);
 
             Route::get('/track-opens/{campaignSendUuid}', TrackOpensController::class);
             Route::get('/track-clicks/{campaignLinkUuid}/{subscriberUuid}', TrackClicksController::class);

--- a/src/Mails/CampaignMail.php
+++ b/src/Mails/CampaignMail.php
@@ -32,6 +32,12 @@ class CampaignMail extends Mailable
     {
         return $this
             ->subject($this->subject)
-            ->view('email-campaigns::mails.campaign');
+            ->view('email-campaigns::mails.campaign')
+            ->withSwiftMessage(function ($message) {
+                $message->getHeaders()
+                        ->addTextHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+                $message->getHeaders()
+                        ->addTextHeader('List-Unsubscribe', '<' . secure_url('unsubscribe/' . $this->campaignSend->subscription->uuid) . '>');
+            });
     }
 }

--- a/tests/Features/UnsubscribeTest.php
+++ b/tests/Features/UnsubscribeTest.php
@@ -71,4 +71,23 @@ class UnsubscribeTest extends TestCase
 
         dispatch(new SendCampaignJob($this->campaign));
     }
+
+    /** @test */
+    public function the_unsubscribe_header_is_added_to_the_email()
+    {
+        Event::listen(MessageSent::class, function (MessageSent $event) {
+
+            $subscription = $this->emailList->allSubscriptions->first();
+
+            $this->assertNotNull($event->message->getHeaders()->get('List-Unsubscribe'));
+
+            $this->assertNotNull($event->message->getHeaders()->get('List-Unsubscribe'));
+
+            $this->assertEquals('List-Unsubscribe=One-Click' ,$event->message->getHeaders()->get('List-Unsubscribe'));
+
+            $this->assertEquals('<'. url('/unsubscribe/'. $subscription->uuid) .'>', $event->message->getHeaders()->get('List-Unsubscribe'));
+        });
+
+        dispatch(new SendCampaignJob($this->campaign));
+    }
 }

--- a/tests/Features/UnsubscribeTest.php
+++ b/tests/Features/UnsubscribeTest.php
@@ -81,11 +81,11 @@ class UnsubscribeTest extends TestCase
 
             $this->assertNotNull($event->message->getHeaders()->get('List-Unsubscribe'));
 
-            $this->assertNotNull($event->message->getHeaders()->get('List-Unsubscribe'));
+            $this->assertEquals('<'. secure_url('/unsubscribe/'. $subscription->uuid) .'>', $event->message->getHeaders()->get('List-Unsubscribe')->getValue());
+            
+            $this->assertNotNull($event->message->getHeaders()->get('List-Unsubscribe-Post'));
 
-            $this->assertEquals('List-Unsubscribe=One-Click' ,$event->message->getHeaders()->get('List-Unsubscribe'));
-
-            $this->assertEquals('<'. url('/unsubscribe/'. $subscription->uuid) .'>', $event->message->getHeaders()->get('List-Unsubscribe'));
+            $this->assertEquals('List-Unsubscribe=One-Click' ,$event->message->getHeaders()->get('List-Unsubscribe-Post')->getValue());
         });
 
         dispatch(new SendCampaignJob($this->campaign));

--- a/tests/Jobs/SendMailJobTest.php
+++ b/tests/Jobs/SendMailJobTest.php
@@ -60,32 +60,4 @@ class SendMailJobTest extends TestCase
         dispatch(new SendMailJob($pendingSend));
         Queue::assertPushedOn('custom-queue', SendMailJob::class);
     }
-
-        /** @test */
-        public function the_unsubscribe_header_is_added_to_the_email()
-        {
-            $pendingSend = factory(CampaignSend::class)->create();
-    
-            dispatch(new SendMailJob($pendingSend));
-    
-            Mail::assertSent(CampaignMail::class, function (CampaignMail $mail) use ($pendingSend) {
-
-                //get headers from the $mail (SwiftMailer)
-
-                $headers = [
-                    'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
-                    'List-Unsubscribe' => '<'.url('/unsubscribe/'.$pendingSend->uuid).'>',
-                ];
-
-                $this->assertArrayHasKey('List-Unsubscribe', $headers);
-
-                $this->assertArrayHasKey('List-Unsubscribe-Post', $headers);
-
-                $this->assertEquals('List-Unsubscribe=One-Click' ,$headers['List-Unsubscribe-Post']);
-
-                $this->assertEquals('<'. url('/unsubscribe/'.$pendingSend->uuid) .'>', $headers['List-Unsubscribe']);
-
-                return true;
-            });
-        }
 }

--- a/tests/Jobs/SendMailJobTest.php
+++ b/tests/Jobs/SendMailJobTest.php
@@ -60,4 +60,32 @@ class SendMailJobTest extends TestCase
         dispatch(new SendMailJob($pendingSend));
         Queue::assertPushedOn('custom-queue', SendMailJob::class);
     }
+
+        /** @test */
+        public function the_unsubscribe_header_is_added_to_the_email()
+        {
+            $pendingSend = factory(CampaignSend::class)->create();
+    
+            dispatch(new SendMailJob($pendingSend));
+    
+            Mail::assertSent(CampaignMail::class, function (CampaignMail $mail) use ($pendingSend) {
+
+                //get headers from the $mail (SwiftMailer)
+
+                $headers = [
+                    'List-Unsubscribe-Post' => 'List-Unsubscribe=One-Click',
+                    'List-Unsubscribe' => '<'.url('/unsubscribe/'.$pendingSend->uuid).'>',
+                ];
+
+                $this->assertArrayHasKey('List-Unsubscribe', $headers);
+
+                $this->assertArrayHasKey('List-Unsubscribe-Post', $headers);
+
+                $this->assertEquals('List-Unsubscribe=One-Click' ,$headers['List-Unsubscribe-Post']);
+
+                $this->assertEquals('<'. url('/unsubscribe/'.$pendingSend->uuid) .'>', $headers['List-Unsubscribe']);
+
+                return true;
+            });
+        }
 }


### PR DESCRIPTION
This PR adds List-Unsubscribe headers to the campaign emails as per [RFC2369](https://www.ietf.org/rfc/rfc2369.txt).

Relates to #29 

This allows subscribers to unsubscribe from their email client.

This does not add ```mailto:``` functionality as this would require additional packages to enable this ability.

Includes a test, implementation and documentation (small paragraph)