### PR TITLE
Only set default status when none was already set

### DIFF
--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -43,7 +43,9 @@ class Campaign extends Model
         parent::boot();
 
         static::creating(function (Campaign $campaign) {
-            $campaign->status = CampaignStatus::CREATED;
+            if (! $campaign->status) {
+                $campaign->status = CampaignStatus::CREATED;
+            }
         });
     }
 

--- a/src/Models/EmailList.php
+++ b/src/Models/EmailList.php
@@ -5,11 +5,11 @@ namespace Spatie\EmailCampaigns\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Validator;
+use Spatie\EmailCampaigns\Models\Concerns\HasUuid;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\EmailCampaigns\Enums\SubscriptionStatus;
 use Spatie\EmailCampaigns\Exceptions\CouldNotSubscribe;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Spatie\EmailCampaigns\Models\Concerns\HasUuid;
 
 class EmailList extends Model
 {


### PR DESCRIPTION
This fixes the status when using it in for example a model factory that already sets a specific status